### PR TITLE
use absolute imports for package modules for python3 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ logging.getLogger().setLevel(logging.INFO)
 ```
 
 # Changelog
-
+* 5.1.1: Use absolute imports for package modules
 * 5.1.0: Include sellingofficename in the information returned from office table lookups
 * 5.0.0: Add requests as a dependency, add retries for failed connections
 * 4.0.2: Reduce image download timeout from 5 minutes to 30 seconds

--- a/evernetpy/__init__.py
+++ b/evernetpy/__init__.py
@@ -1,8 +1,8 @@
 import base64
 import datetime
-from execute import execute_listing_query, execute_photo_query
-from lookups import look_up_all_fields
-from criteria import iterate_criteria
+from evernetpy.execute import execute_listing_query, execute_photo_query
+from evernetpy.lookups import look_up_all_fields
+from evernetpy.criteria import iterate_criteria
 
 TIME_FORMAT_STRING = '%Y-%m-%dT%H:%M:%S'
 

--- a/evernetpy/execute.py
+++ b/evernetpy/execute.py
@@ -1,7 +1,7 @@
 import logging
-from client import EvernetClient
-from query import listing_query, photo_query
-from parser import parse
+from evernetpy.client import EvernetClient
+from evernetpy.query import listing_query, photo_query
+from evernetpy.parser import parse
 
 logger = logging.getLogger(__name__)
 

--- a/evernetpy/lookups.py
+++ b/evernetpy/lookups.py
@@ -1,6 +1,6 @@
-from execute import execute_listing_query
 from collections import defaultdict
-from memoize import memoize
+from evernetpy.execute import execute_listing_query
+from evernetpy.memoize import memoize
 
 office_name_cache = {}
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 setup(name='evernetpy',
-      version='5.1.0',
+      version='5.1.1',
       description="A Python library for interacting with the EverNet listing service",
       author='Kevin McCarthy',
       author_email='me@kevinmccarthy.org',


### PR DESCRIPTION
Python3 introduced explicit relative imports, and so an error is thrown when it reaches the import statements as they currently are.

I've changed them to absolute imports so that both python 2 and 3 are supported